### PR TITLE
Implemented very basic "status-percent-timeout-when-complete" feature

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -19,7 +19,7 @@ export class ProgressWatcher extends EventEmitter {
             });
         }, 1000);
     }
-    
+
     dispose() {
         clearInterval(this.timer);
     }
@@ -27,16 +27,28 @@ export class ProgressWatcher extends EventEmitter {
 
 export class WebpackProgress {
      private statusBarItem: vscode.StatusBarItem;
-     
+     private lastPercentage: number;
+     private resetTimout: any;
+     private statusLabel:string = 'Webpack';
+
      updateProgress(percentage) {
          if(!this.statusBarItem) {
              this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-             this.statusBarItem.text = "Webpack 0%";
+             this.statusBarItem.text = this.statusLabel;
              this.statusBarItem.show();
          }
-         this.statusBarItem.text = `Webpack ${percentage}%`;
+        if (typeof this.lastPercentage === 'undefined') this.statusBarItem.text = this.statusLabel;
+        else this.statusBarItem.text = typeof percentage == 'number' ? `${this.statusLabel} ${percentage}%` : this.statusLabel;
+        if (percentage == 100 && typeof this.lastPercentage !== 'undefined') this.resetProgress();
+        this.lastPercentage = percentage;
      }
-     
+
+    resetProgress() {
+        this.statusBarItem.text = `${this.statusLabel} √`;
+        clearTimeout(this.resetTimout);
+        this.resetTimout = setTimeout(() => this.statusBarItem.text = this.statusLabel, 5000);
+    }
+
      dispose() {
          this.statusBarItem.dispose();
      }


### PR DESCRIPTION
### Brief
This feature changes the behaviour of the extension, so that by default, the status bar text would default to "Webpack".

Once the `percentage` changes, it will show "Webpack ${percentage}". 

Once the `percentage` reaches 100 and if the `lastPercentage` was defined (assuming it will be `undefined` only when the extension is initialized) it will trigger the `resetProgress` method which will display "Webpack √" for a few seconds, then go back to the default "Webpack".

---

### Changes in /src/webpack.ts

#### Class `WebpackProgress`

Now in the `updateProgress` method, if the `percentage` is 100 and the `lastPercentage` was not `undefined`, it calls the `resetProgress` which reset the status bar text to "Webpack √" then after a timeout back to "Webpack".

Also, instead of manually prepending "Webpack" to the status bar text, it now prepends
`this.statusLabel` which defaults to "Webpack", for consistency & separation of concerns.

---

**There are no changes to any other files, tests, scripts or dependencies.**